### PR TITLE
mk-nghttp2.bat: fix missing exports issue in libcurl.dll

### DIFF
--- a/mk-nghttp2.bat
+++ b/mk-nghttp2.bat
@@ -17,7 +17,7 @@ pushd "%_NAM%"
 del /s *.o *.a *.lo *.la *.lai *.Plo *.pc >> nul 2>&1
 if "%_CPU%" == "win32" set LDFLAGS=-m32
 if "%_CPU%" == "win64" set LDFLAGS=-m64
-set CFLAGS=%LDFLAGS% -U__STRICT_ANSI__
+set CFLAGS=%LDFLAGS% -U__STRICT_ANSI__ -DNGHTTP2_STATICLIB
 set CXXFLAGS=%CFLAGS%
 :: Open dummy file descriptor to fix './<script>: line <n>: 0: Bad file descriptor'
 sh -c "exec 0</dev/null && ./configure '--prefix=%CD:\=/%'"


### PR DESCRIPTION
where only nghttp2-related symbols get exported when 
nghttp2 lib is linked to it. Build nghttp2 libs with `-DNGHTTP2_STATICLIB`
so the functions are declared _without_ `__declspec(dllexport)`
like the rest of functions from libcurl and libssh2.