### PR TITLE
openssl: use enable-ec_nistp_64_gcc_128 on 64-bit builds

### DIFF
--- a/_dl.sh
+++ b/_dl.sh
@@ -158,7 +158,7 @@ rm -f -r libssh2 && mv libssh2-* libssh2
 [ -f "libssh2${_patsuf}.diff" ] && dos2unix < "libssh2${_patsuf}.diff" | patch -N -p1 -d libssh2
 # Patch to make libssh2 compatible with OpenSSL 1.1.0. Remove in next version.
 curl -o libssh2.diff -L --proto-redir =https https://github.com/libssh2/libssh2/pull/121.diff
-openssl dgst -sha256 libssh2.diff | grep -q 3a76d6d4ee226e92b8a6da54d545bade1dd0fd870ee6fc5314dbcccfa30f2568 || exit 1
+openssl dgst -sha256 libssh2.diff | grep -q 548f5b5f743f9fd30d8748acf9282a56ed3641f6a6c334010597112b7dadbb65 || exit 1
 [ -f "libssh2${_patsuf}.diff" ] && dos2unix < "libssh2${_patsuf}.diff" | patch -N -p1 -d libssh2
 
 # curl

--- a/_dl.sh
+++ b/_dl.sh
@@ -157,7 +157,7 @@ rm pack.bin
 rm -f -r libssh2 && mv libssh2-* libssh2
 [ -f "libssh2${_patsuf}.diff" ] && dos2unix < "libssh2${_patsuf}.diff" | patch -N -p1 -d libssh2
 # Patch to make libssh2 compatible with OpenSSL 1.1.0. Remove in next version.
-curl -o libssh2.diff -L --proto-redir =https https://github.com/libssh2/libssh2/pull/121.diff
+curl -o libssh2.diff -L --proto-redir =https https://github.com/libssh2/libssh2/commit/64ebfd8182a9b6e637e65c3059e3798e199274b3.diff
 openssl dgst -sha256 libssh2.diff | grep -q 548f5b5f743f9fd30d8748acf9282a56ed3641f6a6c334010597112b7dadbb65 || exit 1
 [ -f "libssh2${_patsuf}.diff" ] && dos2unix < "libssh2${_patsuf}.diff" | patch -N -p1 -d libssh2
 

--- a/openssl.sh
+++ b/openssl.sh
@@ -57,6 +57,7 @@ _cpu="$2"
       no-unit-test \
       no-idea \
       no-dso \
+      enable-cms \
       '--prefix=/usr/local'
    [ "$(echo "${OPENSSL_VER_}" | cut -c -5)" = '1.1.0' ] || make depend
    make

--- a/openssl.sh
+++ b/openssl.sh
@@ -43,8 +43,11 @@ _cpu="$2"
    else
       options="${options} no-filenames"
    fi
-   # Requires mingw 5.0 or upper
-   [ "${_cpu}" = '64' ] && options="${options} -Wl,--high-entropy-va -Wl,--image-base,0x151000000"
+   if [ "${_cpu}" = '64' ] ; then
+      options="${options} enable-ec_nistp_64_gcc_128"
+      # Requires mingw 5.0 or upper
+      options="${options} -Wl,--high-entropy-va -Wl,--image-base,0x151000000"
+   fi
 
    # AR=, NM=, RANLIB=
 
@@ -57,7 +60,6 @@ _cpu="$2"
       no-unit-test \
       no-idea \
       no-dso \
-      enable-cms \
       '--prefix=/usr/local'
    [ "$(echo "${OPENSSL_VER_}" | cut -c -5)" = '1.1.0' ] || make depend
    make


### PR DESCRIPTION
* libssh2 patch maintenance updates
